### PR TITLE
adjust traefik service ip to original from nginx

### DIFF
--- a/cluster/base/cluster-settings.yaml
+++ b/cluster/base/cluster-settings.yaml
@@ -6,4 +6,4 @@ metadata:
   namespace: flux-system
 data:
   METALLB_LB_RANGE: 192.168.1.210-192.168.1.229
-  SVC_TRAEFIK_ADDR: 192.168.1.211
+  SVC_TRAEFIK_ADDR: 192.168.1.210


### PR DESCRIPTION
In hindsight this wasn't neccessary, but i gave traefik a different ip
than the one used for nginx originally thinking that they would conflict
if i just fed the existing ip to traefik while flux and helm were trying
to shuffle out nginx and deploy helm. In hindsight this wasn't
neccessary since this all works on eventual consistency, and a failure
to deploy traefik due to the conflict in address would have just meant
it was fixed on the next pass. Ohes well, fixing it now so dns matches
the right ip.
