### PR TITLE
Update homer ingress annotation

### DIFF
--- a/cluster/apps/default/homer/helm-release.yaml
+++ b/cluster/apps/default/homer/helm-release.yaml
@@ -24,7 +24,7 @@ spec:
       main:
         enabled: true
         annotations:
-          kubernetes.io/ingress.class: "traefik"
+          ingressClassName: "traefik"
         hosts:
         - host: "homer.${SECRET_DOMAIN}"
           paths:


### PR DESCRIPTION
traefik only supports the newer ingressClassName annotation, while nginx
ingress was perfectly happy with the old kubernetes.io/ingress.class.