### PR TITLE
update rook-ceph-crds to 1.7.2

### DIFF
--- a/cluster/crds/rook-ceph/crds.yaml
+++ b/cluster/crds/rook-ceph/crds.yaml
@@ -9,7 +9,7 @@ spec:
   url: https://github.com/rook/rook.git
   ref:
     # renovate: registryUrl=https://charts.rook.io/release chart=rook-ceph
-    tag: v1.7.1
+    tag: v1.7.2
   ignore: |
     # exclude all
     /*


### PR DESCRIPTION
Not sure why renovate bot didn't catch this with the other updates to
the rook-ceph helm releases.
