### PR TITLE
disable https redirect on traefik web entrypoint

### DIFF
--- a/cluster/apps/networking/traefik/helm-release.yaml
+++ b/cluster/apps/networking/traefik/helm-release.yaml
@@ -61,8 +61,8 @@ spec:
     ports:
       traefik:
         expose: true
-      web:
-        redirectTo: websecure
+      # web:
+      #   redirectTo: websecure
       websecure:
         tls:
           enabled: true


### PR DESCRIPTION
I couldn't find a way to disable this per ingress, so testing this
change to see if it works.