### PR TITLE
disable serviceMonitor for velero

### DIFF
--- a/cluster/apps/velero/helm-release.yaml
+++ b/cluster/apps/velero/helm-release.yaml
@@ -52,8 +52,8 @@ spec:
           ttl: "120h"
     metrics:
       enabled: true
-      serviceMonitor:
-        enabled: true
+      # serviceMonitor:
+      #   enabled: true
     snapshotsEnabled: true
     upgradeCRDs: false
     cleanUpCRDs: false


### PR DESCRIPTION
flu is throwing helm release error:
 Helm install failed: unable to build kubernetes objects from release manifest: unable to recognize "": no matches for kind "ServiceMonitor" in version "monitoring.coreos.com/v1"