### PR TITLE
update crd to velero-2.23.8

### DIFF
--- a/cluster/crds/velero/crds.yaml
+++ b/cluster/crds/velero/crds.yaml
@@ -9,7 +9,7 @@ spec:
   url: https://github.com/vmware-tanzu/helm-charts.git
   ref:
     # renovate: registryUrl=https://vmware-tanzu.github.io/helm-charts
-    tag: velero-2.23.6
+    tag: velero-2.23.8
   ignore: |
     # exclude all
     /*


### PR DESCRIPTION
renovate bot refuses to do it for some reason
