### PR TITLE
add supplemental security groups for video & users

### DIFF
--- a/cluster/apps/media/plex/helm-release.yaml
+++ b/cluster/apps/media/plex/helm-release.yaml
@@ -22,11 +22,10 @@ spec:
       tag: v1.24.5.5173-8dcc73a59
     env:
       TZ: "America/New_York"
-    # podSecurityContext:
-    #   supplementalGroups:
-    #     - 44
-    #     - 109
-    #     - 100
+    podSecurityContext:
+      supplementalGroups:
+        - 44
+        - 100
     service:
       main:
         type: LoadBalancer


### PR DESCRIPTION
The nfs mount is showing up in the container without proper permissions
for the kah user. Wondering if this setting will help fix it.
