### PR TITLE
set individual cert for plex

### DIFF
--- a/cluster/apps/media/plex/helm-release.yaml
+++ b/cluster/apps/media/plex/helm-release.yaml
@@ -37,6 +37,7 @@ spec:
         enabled: true
         ingressClassName: "traefik"
         annotations:
+          cert-manager.io/cluster-issuer: "letsencrypt-production"
           # external-dns.alpha.kubernetes.io/target: "ipv4.${SECRET_DOMAIN}"
           # external-dns/is-public: "true"
           # hajimari.io/enable: "true"
@@ -50,6 +51,7 @@ spec:
         tls:
           - hosts:
               - "plex-test.${SECRET_DOMAIN}"
+            secretName: "plex-tls"
     persistence:
       config:
         enabled: true


### PR DESCRIPTION
This is to avoid the issues we were having with the wildcard certs
after the cluster rebuild.
