### PR TITLE
add node-feature-disocvery

### DIFF
--- a/cluster/apps/kube-system/node-feature-discovery/helm-release.yaml
+++ b/cluster/apps/kube-system/node-feature-discovery/helm-release.yaml
@@ -31,4 +31,3 @@ spec:
             - pciId:
                 class: ["0300"]
                 vendor: ["8086"]
-

--- a/cluster/apps/kube-system/node-feature-discovery/helm-release.yaml
+++ b/cluster/apps/kube-system/node-feature-discovery/helm-release.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: node-feature-discovery
+  namespace: kube-system
+spec:
+  interval: 5m
+  chart:
+    spec:
+      # renovate: registryUrl=https://kubernetes-sigs.github.io/node-feature-discovery/charts
+      chart: node-feature-discovery
+      version: 0.9.0
+      sourceRef:
+        kind: HelmRepository
+        name: node-feature-discovery-charts
+        namespace: flux-system
+  values:
+    worker:
+      annotations:
+        configmap.reloader.stakater.com/reload: "nfd-worker-conf"
+      nodeSelector:
+        node-role.kubernetes.io/worker: "true"
+      config: |-
+        core:
+          sources:
+          - custom
+          custom:
+          - name: "intel-gpu"
+            matchOn:
+            - pciId:
+                class: ["0300"]
+                vendor: ["8086"]
+

--- a/cluster/apps/kube-system/node-feature-discovery/kustomization.yaml
+++ b/cluster/apps/kube-system/node-feature-discovery/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/cluster/apps/kube-system/node-feature-discovery/kustomization.yaml
+++ b/cluster/apps/kube-system/node-feature-discovery/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helm-release.yaml


### PR DESCRIPTION
allows the tagging of instances based on features, in this case, the presence of the built in intel gpu for use by plex.