### PR TITLE
remove node selector for worker config

### DIFF
--- a/cluster/apps/kube-system/node-feature-discovery/helm-release.yaml
+++ b/cluster/apps/kube-system/node-feature-discovery/helm-release.yaml
@@ -17,10 +17,6 @@ spec:
         namespace: flux-system
   values:
     worker:
-      annotations:
-        configmap.reloader.stakater.com/reload: "nfd-worker-conf"
-      nodeSelector:
-        node-role.kubernetes.io/worker: "true"
       config: |-
         core:
           sources:


### PR DESCRIPTION
removing this because i'm wondering if it's looking for worker nodes to label, and I have no workers, only masters