### PR TITLE
remove usb and pci sources

### DIFF
--- a/cluster/apps/kube-system/node-feature-discovery/helm-release.yaml
+++ b/cluster/apps/kube-system/node-feature-discovery/helm-release.yaml
@@ -21,21 +21,6 @@ spec:
         core:
           sources:
           - custom
-          - pci
-          - usb
-        sources:
-          usb:
-            deviceClassWhitelist:
-            - "02"
-            - "03"
-            - "0e"
-            - "ef"
-            - "fe"
-            - "ff"
-            deviceLabelFields:
-            - "class"
-            - "vendor"
-            - "device"
           custom:
           - name: "intel-gpu"
             matchOn:


### PR DESCRIPTION
The hope is that with the node selection criteria removed, the custom label will stick and there's no need for the other feature labels.