### PR TITLE
force deletion of homer helm release

### DIFF
--- a/cluster/apps/kustomization.yaml
+++ b/cluster/apps/kustomization.yaml
@@ -2,7 +2,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- default
+# - default
 - networking
 - system-upgrade
 - kube-system


### PR DESCRIPTION
flux seems to be having issues deploying the updates to the helm release
 from 6.01 > 7.0.0. I'm hoping by cleaning out all the resources and
 then readding them, that it will work again.