### PR TITLE
shift kured image to weaveworks image repo

### DIFF
--- a/cluster/apps/kube-system/kured/helm-release.yaml
+++ b/cluster/apps/kube-system/kured/helm-release.yaml
@@ -18,7 +18,7 @@ spec:
       interval: 5m
   values:
     image:
-      repository: ghcr.io/k8s-at-home/kured
+      repository: ghcr.io/weaveworks/kured
     updateStrategy: RollingUpdate
     configuration:
       timeZone: "America/New_York"


### PR DESCRIPTION
This was mirrored in the k8s-at-home container registry on github
because originally weaveworks only maintained images on dockerhub which
has rate limits. Now that they support ghcr, we can use the source
directly. Also the k8s mirror was removed so it no longer gets updated
in the k8s-at-home ghcr, and was throwing errors during image pull as a
result.