### PR TITLE
enable monitoring for rook operator

### DIFF
--- a/cluster/core/rook-ceph/helm-release.yaml
+++ b/cluster/core/rook-ceph/helm-release.yaml
@@ -18,6 +18,8 @@ spec:
   values:
     crds:
       enabled: false
+    monitoring:
+      enabled: true
     resources:
       requests:
         cpu: 100m


### PR DESCRIPTION
The 1.8.1 upgrade is failing, the operator won't start succesfully.
Attempting this on the reccomendation from k8s-at-home community.