### PR TITLE
set vpn-gateway HR namespace

### DIFF
--- a/cluster/apps/vpn-gateway/helm-release.yaml
+++ b/cluster/apps/vpn-gateway/helm-release.yaml
@@ -3,7 +3,7 @@ apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease
 metadata:
   name: vpn-gateway
-#  namespace: vpn-gateway
+  namespace: vpn-gateway
 spec:
   interval: 5m
   chart:


### PR DESCRIPTION
flux was throwing errors that the namespace wasn't specified. I
think it's required. We'll try it this way to see what happens.