### PR TITLE
revert rook-ceph from 1.8.2 to 1.7.10

### DIFF
--- a/cluster/core/rook-ceph/helm-release.yaml
+++ b/cluster/core/rook-ceph/helm-release.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       # renovate: registryUrl=https://charts.rook.io/release
       chart: rook-ceph
-      version: v1.8.2
+      version: v1.7.10
       sourceRef:
         kind: HelmRepository
         name: rook-ceph-charts

--- a/cluster/core/rook-ceph/rook-direct-mount/deployment.yaml
+++ b/cluster/core/rook-ceph/rook-direct-mount/deployment.yaml
@@ -19,7 +19,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: rook-direct-mount
-          image: rook/ceph:v1.8.2
+          image: rook/ceph:v1.7.10
           command: ["/bin/bash"]
           args: ["-m", "-c", "/usr/local/bin/toolbox.sh"]
           imagePullPolicy: IfNotPresent

--- a/cluster/core/rook-ceph/storage/helm-release.yaml
+++ b/cluster/core/rook-ceph/storage/helm-release.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       # renovate: registryUrl=https://charts.rook.io/release
       chart: rook-ceph-cluster
-      version: v1.8.2
+      version: v1.7.10
       sourceRef:
         kind: HelmRepository
         name: rook-ceph-charts

--- a/cluster/crds/rook-ceph/crds.yaml
+++ b/cluster/crds/rook-ceph/crds.yaml
@@ -9,12 +9,12 @@ spec:
   url: https://github.com/rook/rook.git
   ref:
     # renovate: registryUrl=https://charts.rook.io/release chart=rook-ceph
-    tag: v1.8.2
+    tag: v1.7.10
   ignore: |
     # exclude all
     /*
     # path to crds
-    !/deploy/examples/ceph/crds.yaml
+    !/cluster/examples/kubernetes/ceph/crds.yaml
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
 kind: Kustomization


### PR DESCRIPTION
still having issue with rook 1.8 operator failing with error. See rook/rook issue 9132.