### PR TITLE
update vpn-gateway routed_namespaces to media

### DIFF
--- a/cluster/apps/vpn-gateway/helm-release.yaml
+++ b/cluster/apps/vpn-gateway/helm-release.yaml
@@ -19,7 +19,7 @@ spec:
   # See https://github.com/k8s-at-home/charts/blob/master/charts/pod-gateway/values.yaml
   values:
     routed_namespaces:
-      - vpn-routed-namespace
+      - media
     settings:
       # VPN_INTERFACE: wg0
       VPN_BLOCK_OTHER_TRAFFIC: true


### PR DESCRIPTION
This was missed when shifting from vpn-routed-namespace to media in the previous commit. It caused the configmap to be  created in the wrong namespace, and therefore wasn't available to the test po in the media namespace.