### PR TITLE
fix crds path in rook-ceph-source repo

### DIFF
--- a/cluster/crds/rook-ceph/crds.yaml
+++ b/cluster/crds/rook-ceph/crds.yaml
@@ -14,7 +14,7 @@ spec:
     # exclude all
     /*
     # path to crds
-    !/deploy/examples/ceph/crds.yaml
+    !/deploy/examples/crds.yaml
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
 kind: Kustomization


### PR DESCRIPTION
path was incorrect. was causing ceph upgrade to fail.