### PR TITLE
actually enable vpn gateway for transmission

### DIFF
--- a/cluster/apps/media/transmission/helm-release.yaml
+++ b/cluster/apps/media/transmission/helm-release.yaml
@@ -63,7 +63,6 @@ spec:
           # hajimari.io/enable: "true"
           # hajimari.io/icon: "transmission"
           traefik.ingress.kubernetes.io/router.entrypoints: "websecure"
-          setGateway: "true"
         hosts:
           - host: "transmission.${SECRET_DOMAIN}"
             paths:
@@ -73,6 +72,9 @@ spec:
           - hosts:
               - "transmission.${SECRET_DOMAIN}"
             secretName: "transmission-tls"
+    podAnnotations:
+      # backup.velero.io/backup-volumes: config
+      setGateway: "true"
     probes:
       liveness:
         spec:


### PR DESCRIPTION
had annotation in the wrong places, which means the sidecar container wasn't triggered, which means it wasn't getting put directed to the vpn gateway.