### PR TITLE
remove custom-webui name in transmission

### DIFF
--- a/cluster/apps/media/transmission/helm-release.yaml
+++ b/cluster/apps/media/transmission/helm-release.yaml
@@ -94,7 +94,7 @@ spec:
         mountPath: /watch
     initContainers:
       custom-webui:
-        name: custom-webui
+        # name: custom-webui
         image: curlimages/curl:7.76.1
         command:
           - "/bin/sh"


### PR DESCRIPTION
the helm chart through errors on the name value, so trying to remove it to see if it resolves the error