### PR TITLE
remove custom-webui initcontainer for transmission

### DIFF
--- a/cluster/apps/media/transmission/helm-release.yaml
+++ b/cluster/apps/media/transmission/helm-release.yaml
@@ -92,17 +92,17 @@ spec:
       watch:
         enabled: false
         mountPath: /watch
-    initContainers:
-      custom-webui:
-        # name: custom-webui
-        image: curlimages/curl:7.76.1
-        command:
-          - "/bin/sh"
-          - "-c"
-          - "curl -o- -sL https://github.com/johman10/flood-for-transmission/releases/download/latest/flood-for-transmission.tar.gz | tar xzf - -C /config"
-        volumeMounts:
-          - name: config
-            mountPath: /config
-        securityContext:
-          runAsUser: 568
-          runAsGroup: 568
+    # initContainers:
+    #   custom-webui:
+    #     name: custom-webui
+    #     image: curlimages/curl:7.76.1
+    #     command:
+    #       - "/bin/sh"
+    #       - "-c"
+    #       - "curl -o- -sL https://github.com/johman10/flood-for-transmission/releases/download/latest/flood-for-transmission.tar.gz | tar xzf - -C /config"
+    #     volumeMounts:
+    #       - name: config
+    #         mountPath: /config
+    #     securityContext:
+    #       runAsUser: 568
+    #       runAsGroup: 568


### PR DESCRIPTION
the volumeMount.name wouldn't reconcile with the helm chart. Removing for now and will come back to it later.