### PR TITLE
set transmission download path to media volume

### DIFF
--- a/cluster/apps/media/sonarr/helm-release.yaml
+++ b/cluster/apps/media/sonarr/helm-release.yaml
@@ -22,6 +22,7 @@ spec:
       tag: v3.0.6.1342
     env:
       TZ: "America/New_York"
+      TRANSMISSION_DOWNLOAD_DIR: /media/Downloads/transmission_complete
     ingress:
       main:
         enabled: true


### PR DESCRIPTION
Should allow sharing of data across apps (plex, sonarr, transmission, etc)