### PR TITLE
adjusting name of symlink configmap

### DIFF
--- a/cluster/apps/media/sonarr/helm-release.yaml
+++ b/cluster/apps/media/sonarr/helm-release.yaml
@@ -58,7 +58,7 @@ spec:
       reverse-symlink:
         enabled: true
         type: configMap
-        name: reverse-symlink
+        name: sonarr-reverse-symlink
         mountPath: /config/scripts/
         subPath: reverse-symlink.sh
     resources:


### PR DESCRIPTION
the configmap can't be mounted as a volume because it's looking for a confmap named 'reverse-symlink' but the actual name of the configmap getting generated here is sonarr-reverse-symlink. So trying to hard code this to see if it works.