### PR TITLE
make reverse-symlink  a custom persistence type

### DIFF
--- a/cluster/apps/media/sonarr/helm-release.yaml
+++ b/cluster/apps/media/sonarr/helm-release.yaml
@@ -57,10 +57,14 @@ spec:
         mountPath: /media
       reverse-symlink:
         enabled: true
-        type: configMap
-        name: sonarr-reverse-symlink
+        type: custom
+        volumeSpec: 
+          configMap:
+            name: sonarr-reverse-symlink
+            items:
+              - key: data
+                path: reverse-symlink.sh
         mountPath: /config/scripts/
-        subPath: reverse-symlink.sh
     resources:
       requests:
         memory: 250Mi

--- a/cluster/apps/media/sonarr/helm-release.yaml
+++ b/cluster/apps/media/sonarr/helm-release.yaml
@@ -58,7 +58,7 @@ spec:
       reverse-symlink:
         enabled: true
         type: custom
-        volumeSpec: 
+        volumeSpec:
           configMap:
             name: sonarr-reverse-symlink
             items:


### PR DESCRIPTION
the previous configuration wasn't mounting properly, instead just creating a '/config/scripts' file, with root perms