### PR TITLE
fix reverse-symlink configmap key volume spec

### DIFF
--- a/cluster/apps/media/sonarr/helm-release.yaml
+++ b/cluster/apps/media/sonarr/helm-release.yaml
@@ -62,7 +62,7 @@ spec:
           configMap:
             name: sonarr-reverse-symlink
             items:
-              - key: data
+              - key: reverse-symlink.sh
                 path: reverse-symlink.sh
         mountPath: /config/scripts/
     resources:


### PR DESCRIPTION
error was non-existent config key: data