### PR TITLE
remove full path from reverse-symlink path

### DIFF
--- a/cluster/apps/media/sonarr/helm-release.yaml
+++ b/cluster/apps/media/sonarr/helm-release.yaml
@@ -62,7 +62,7 @@ spec:
         defaultMode: 0777
         items:
           - key: reverse-symlink.sh
-            path: /config/scripts/reverse-symlink.sh
+            path: reverse-symlink.sh
     resources:
       requests:
         memory: 250Mi


### PR DESCRIPTION
must be a relative path