### PR TITLE
rename reverse-symlink mount

### DIFF
--- a/cluster/apps/media/sonarr/helm-release.yaml
+++ b/cluster/apps/media/sonarr/helm-release.yaml
@@ -55,14 +55,11 @@ spec:
             server: "${NAS_ADDR}"
             path: /volume2/Media
         mountPath: /media
-      reverse-symlink:
+      scripts:
         enabled: true
         type: configMap
         name: sonarr-reverse-symlink
         defaultMode: 0777
-        items:
-          - key: reverse-symlink.sh
-            path: reverse-symlink.sh
     resources:
       requests:
         memory: 250Mi


### PR DESCRIPTION
trying to move around the mount point for the script. It previously mounted to /reverse-symlink/..2022_01_23_02_32_44.218186749/reverse-symlink.sh with some very weird softlinks chaining to it from /reverse-symlink/