### PR TITLE
add transmission downloads pvc

### DIFF
--- a/cluster/apps/media/transmission/downloads-pvc.yaml
+++ b/cluster/apps/media/transmission/downloads-pvc.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: transmission-downloads-v1
+  namespace: media
+  labels:
+    app.kubernetes.io/name: "transmission"
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Gi
+  storageClassName: ceph-block

--- a/cluster/apps/media/transmission/helm-release.yaml
+++ b/cluster/apps/media/transmission/helm-release.yaml
@@ -25,7 +25,7 @@ spec:
     env:
       TZ: "America/New_York"
       TRANSMISSION_RPC_PASSWORD: "${SECRET_TRANSMISSION_RPC_PASSWORD}"
-      TRANSMISSION_DOWNLOAD_DIR: /media/Downloads/transmission_complete
+      TRANSMISSION_DOWNLOAD_DIR: /downloads
     service:
       main:
         type: LoadBalancer
@@ -88,7 +88,8 @@ spec:
         mountPath: /media
         readOnly: false
       downloads:
-        enabled: false
+        enabled: true
+        existingClaim: transmission-downloads-v1
         mountPath: /downloads
       watch:
         enabled: false

--- a/cluster/apps/media/transmission/kustomization.yaml
+++ b/cluster/apps/media/transmission/kustomization.yaml
@@ -3,4 +3,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - config-pvc.yaml
+  - downloads-pvc.yaml
   - helm-release.yaml


### PR DESCRIPTION
This has to be in a pvc because of the softlinks that i'm planning to use won't get properly backed up to the ntfs volume that is used for backups of the media nfs volume on the NAS. Softlinks won't copy properly to an ntfs volume, so we want to use velero to backup the downloads pvc which will contain alot of softlinks post processing from sonarr and other tools.
