### PR TITLE
add downloads volume to sonarr

### DIFF
--- a/cluster/apps/media/sonarr/helm-release.yaml
+++ b/cluster/apps/media/sonarr/helm-release.yaml
@@ -54,6 +54,10 @@ spec:
             server: "${NAS_ADDR}"
             path: /volume2/Media
         mountPath: /media
+      downloads:
+        enabled: true
+        existingClaim: transmission-downloads-v1
+        mountPath: /downloads
       scripts:
         enabled: true
         type: configMap


### PR DESCRIPTION
sonarr needs to be able to access the downloads pvc where transmission puts new content so it can be processed and moved to the proper location on the nfs share.