### PR TITLE
shift downloads to nfs for transmission and sonarr

### DIFF
--- a/cluster/apps/media/sonarr/helm-release.yaml
+++ b/cluster/apps/media/sonarr/helm-release.yaml
@@ -56,7 +56,11 @@ spec:
         mountPath: /media
       downloads:
         enabled: true
-        existingClaim: transmission-downloads-v1
+        type: custom
+        volumeSpec:
+          nfs:
+            server: "${NAS_ADDR}"
+            path: /volume9/downloads
         mountPath: /downloads
       scripts:
         enabled: true

--- a/cluster/apps/media/transmission/helm-release.yaml
+++ b/cluster/apps/media/transmission/helm-release.yaml
@@ -109,7 +109,11 @@ spec:
         readOnly: false
       downloads:
         enabled: true
-        existingClaim: transmission-downloads-v1
+        type: custom
+        volumeSpec:
+          nfs:
+            server: "${NAS_ADDR}"
+            path: /volume9/downloads
         mountPath: /downloads
       watch:
         enabled: false


### PR DESCRIPTION
data has been replicated to the nfs share. This is being done because you can't use ReadWriteMany on RDB File volumes, only block devices. We could shift to useing Cephfs, however upon further reflection, this really should belong on the nfs any way. 

The only reason it was on rook-ceph in the first place is to make backups of the data easier since it contains softlinks that can't be copied to ntfs volumes on the backup drive. However, we may have an opportunity  to resolve that by moving the usb drives to be directly attached to the NAS. Either that or i'll need to tar the files and back them up to ntfs
