### PR TITLE
remove app label for homer

### DIFF
--- a/cluster/apps/default/homer/helm-release.yaml
+++ b/cluster/apps/default/homer/helm-release.yaml
@@ -19,8 +19,6 @@ spec:
       repository: b4bz/homer
       tag: 21.09.2
       pullPolicy: IfNotPresent
-    podLabels:
-      app: homer
     ingress:
       main:
         enabled: true


### PR DESCRIPTION
it's redundant the k8s at home library chart already labels things with app.kubernetes.io/name