### PR TITLE
remove rook-ceph crds from crds dir

### DIFF
--- a/cluster/crds/kustomization.yaml
+++ b/cluster/crds/kustomization.yaml
@@ -2,5 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - traefik
-- rook-ceph
 - velero


### PR DESCRIPTION
these are managed by the helm chart now
