### PR TITLE
remove debugging from sonarr symlink script

### DIFF
--- a/cluster/apps/media/sonarr/reverse-symlink.sh
+++ b/cluster/apps/media/sonarr/reverse-symlink.sh
@@ -3,9 +3,6 @@
 PERMPATH="$sonarr_episodefile_path"
 LINKPATH="$sonarr_episodefile_sourcepath"
 
-echo "LINKPATH=$LINKPATH" >> /config/logs/script.log
-echo "PERMPATH=$PERMPATH" >> /config/logs/script.log
-
 if [[ -f "$LINKPATH" ]]; then
     sleep 1
 else


### PR DESCRIPTION
The issue was a mis-configuration on the connection within sonarr. I had set a tag on the custom script, which I thought was
 supposed to add a tag to the entry, but instead it was filtering on that tag. Removing the tag filter fixed it.