### PR TITLE
roll back traefik chart version to 10.14.1

### DIFF
--- a/cluster/apps/networking/traefik/helm-release.yaml
+++ b/cluster/apps/networking/traefik/helm-release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: traefik
-      version: 10.14.2
+      version: 10.14.1
       sourceRef:
         kind: HelmRepository
         name: traefik-charts

--- a/cluster/crds/traefik/crds.yaml
+++ b/cluster/crds/traefik/crds.yaml
@@ -9,7 +9,7 @@ spec:
   url: https://github.com/traefik/traefik-helm-chart.git
   ref:
     # renovate: registryUrl=https://helm.traefik.io/traefik chart=traefik
-    tag: v10.14.2
+    tag: v10.14.1
   ignore: |
     # exclude all
     /*


### PR DESCRIPTION
The new version uses 2.6.1 of the traefik app version, which isn't available in the k8s-at-home repo currently due to a build failure. Rolling back until that can be resolved.