### PR TITLE
update traefik chart to 10.14.2

### DIFF
--- a/cluster/apps/networking/traefik/helm-release.yaml
+++ b/cluster/apps/networking/traefik/helm-release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: traefik
-      version: 10.14.1
+      version: 10.14.2
       sourceRef:
         kind: HelmRepository
         name: traefik-charts

--- a/cluster/crds/traefik/crds.yaml
+++ b/cluster/crds/traefik/crds.yaml
@@ -9,7 +9,7 @@ spec:
   url: https://github.com/traefik/traefik-helm-chart.git
   ref:
     # renovate: registryUrl=https://helm.traefik.io/traefik chart=traefik
-    tag: v10.14.1
+    tag: v10.14.2
   ignore: |
     # exclude all
     /*


### PR DESCRIPTION
The issue with the 2.6.1 version of the traefik app container is resolved in the k8s-at-home package repo and this can now proceed.