### PR TITLE
remove hosts prefix from loki ingress config

### DIFF
--- a/cluster/apps/observability/loki/helm-release.yaml
+++ b/cluster/apps/observability/loki/helm-release.yaml
@@ -25,7 +25,7 @@ spec:
         cert-manager.io/cluster-issuer: "letsencrypt-production"
         traefik.ingress.kubernetes.io/router.entrypoints: "websecure"
       hosts:
-        host: "loki.${SECRET_DOMAIN}"
+        - "loki.${SECRET_DOMAIN}"
       tls:
         - hosts:
             - "loki.${SECRET_DOMAIN}"


### PR DESCRIPTION
helm reconciler still throwing errors about the syntax.