### PR TITLE
turn off serviceMonitor on grafana

### DIFF
--- a/cluster/apps/observability/grafana/helm-release.yaml
+++ b/cluster/apps/observability/grafana/helm-release.yaml
@@ -96,8 +96,8 @@ spec:
       - grafana-piechart-panel
       - grafana-worldmap-panel
       - grafana-clock-panel
-    serviceMonitor:
-      enabled: true
+    # serviceMonitor:
+    #   enabled: true
     ingress:
       enabled: true
       ingressClassName: "traefik"


### PR DESCRIPTION
helm throwing error "Reconciler error Helm install failed: unable to build kubernetes objects from release manifest: unable to recognize "": no matches for kind "ServiceMonitor" in version "monitoring.coreos.com/v1""