### PR TITLE
wrap liveness prob in single quotes

### DIFF
--- a/cluster/apps/vpn-gateway/helm-release.yaml
+++ b/cluster/apps/vpn-gateway/helm-release.yaml
@@ -67,7 +67,7 @@ spec:
             command:
               - sh
               - -c
-              - if [ $(curl -s http://ip-api.com/line/?fields=2) = 'NL' ]; then exit 0; else exit $?; fi
+              - 'if [ $(curl -s http://ip-api.com/line/?fields=2) = "NL" ]; then exit 0; else exit $?; fi'
           initialDelaySeconds: 30
           periodSeconds: 90
           failureThreshold: 3


### PR DESCRIPTION
it appears to be failing liveness probe and restarting wireguard pod on timeout. The cmd without quotes in the exec -it container was getting

bash: syntax error near unexpected token `fi'