### PR TITLE
update helm chart repo timings

### DIFF
--- a/cluster/base/flux-system/charts/helm/bitnami-charts.yaml
+++ b/cluster/base/flux-system/charts/helm/bitnami-charts.yaml
@@ -5,6 +5,6 @@ metadata:
   name: bitnami-charts
   namespace: flux-system
 spec:
-  interval: 30m
+  interval: 1h
   url: https://charts.bitnami.com/bitnami
-  timeout: 2m
+  timeout: 3m

--- a/cluster/base/flux-system/charts/helm/grafana-charts.yaml
+++ b/cluster/base/flux-system/charts/helm/grafana-charts.yaml
@@ -5,6 +5,6 @@ metadata:
   name: grafana-charts
   namespace: flux-system
 spec:
-  interval: 15m
+  interval: 1h
   url: https://grafana.github.io/helm-charts
   timeout: 3m

--- a/cluster/base/flux-system/charts/helm/ingress-nginx-charts.yaml
+++ b/cluster/base/flux-system/charts/helm/ingress-nginx-charts.yaml
@@ -5,6 +5,6 @@ metadata:
   name: ingress-nginx-charts
   namespace: flux-system
 spec:
-  interval: 30m
+  interval: 1h
   url: https://kubernetes.github.io/ingress-nginx
-  timeout: 2m
+  timeout: 3m

--- a/cluster/base/flux-system/charts/helm/jetstack-charts.yaml
+++ b/cluster/base/flux-system/charts/helm/jetstack-charts.yaml
@@ -5,6 +5,6 @@ metadata:
   name: jetstack-charts
   namespace: flux-system
 spec:
-  interval: 30m
+  interval: 1h
   url: https://charts.jetstack.io/
-  timeout: 2m
+  timeout: 3m

--- a/cluster/base/flux-system/charts/helm/k8s-at-home-charts.yaml
+++ b/cluster/base/flux-system/charts/helm/k8s-at-home-charts.yaml
@@ -5,6 +5,6 @@ metadata:
   name: k8s-at-home-charts
   namespace: flux-system
 spec:
-  interval: 30m
+  interval: 1h
   url: https://k8s-at-home.com/charts/
-  timeout: 2m
+  timeout: 3m

--- a/cluster/base/flux-system/charts/helm/metallb-charts.yaml
+++ b/cluster/base/flux-system/charts/helm/metallb-charts.yaml
@@ -5,6 +5,6 @@ metadata:
   name: metallb-charts
   namespace: flux-system
 spec:
-  interval: 30m
+  interval: 1h
   url: https://metallb.github.io/metallb
-  timeout: 2m
+  timeout: 3m

--- a/cluster/base/flux-system/charts/helm/node-feature-discovery-charts.yaml
+++ b/cluster/base/flux-system/charts/helm/node-feature-discovery-charts.yaml
@@ -5,6 +5,6 @@ metadata:
   name: node-feature-discovery-charts
   namespace: flux-system
 spec:
-  interval: 15m
+  interval: 1h
   url: https://kubernetes-sigs.github.io/node-feature-discovery/charts
   timeout: 3m


### PR DESCRIPTION
getting errors on the bitnami chart repo every few hours:

failed to fetch Helm repository index: failed to cache index to temporary file: context deadline exceeded (Client.Timeout or context cancellation while reading body)

and

failed to fetch Helm repository index: failed to cache index to temporary file: unexpected EOF

When looking at other people's repo's they have higher intervals and timeouts for most repos, so updating to match to see if it resolves the issue.