### PR TITLE
change bitnami chart source url

### DIFF
--- a/cluster/base/flux-system/charts/helm/bitnami-charts.yaml
+++ b/cluster/base/flux-system/charts/helm/bitnami-charts.yaml
@@ -6,5 +6,5 @@ metadata:
   namespace: flux-system
 spec:
   interval: 1h
-  url: https://charts.bitnami.com/bitnami
+  url: https://raw.githubusercontent.com/bitnami/charts/index/bitnami
   timeout: 3m


### PR DESCRIPTION
have been getting persistent errors from flux every few hours like the below:

helmrepository/bitnami-charts.flux-system
failed to fetch Helm repository index: failed to cache index to temporary file: unexpected EOF

helmrepository/bitnami-charts.flux-system
failed to fetch Helm repository index: failed to cache index to temporary file: context deadline exceeded (Client.Timeout or context cancellation while reading body)

In researching the issue, i found this comment, so i'm going to try it here. https://github.com/rancher/rancher/issues/37136#issuecomment-1086704276