### PR TITLE
enable rabbitmq cluster

### DIFF
--- a/cluster/apps/kustomization.yaml
+++ b/cluster/apps/kustomization.yaml
@@ -11,3 +11,4 @@ resources:
 - media
 - vpn-gateway
 - observability
+- worklab


### PR DESCRIPTION
testing bitnami chart source to make sure it still works with the new source url. will disable shortly.