### PR TITLE
disable podmonitor on vector aggregator

### DIFF
--- a/cluster/apps/observability/vector/aggregator/helm-release.yaml
+++ b/cluster/apps/observability/vector/aggregator/helm-release.yaml
@@ -79,8 +79,6 @@ spec:
               {{`{{ kubernetes.pod_node_name }}`}}
             pod: >-
               {{`{{ kubernetes.pod_name }}`}}
-    podMonitor:
-      enabled: true
     service:
       enabled: true
       type: LoadBalancer


### PR DESCRIPTION
it was throwing errors in flux helm reconciler process;

error HelmRelease/vector-aggregator.observability - Reconciler error Helm install failed: unable to build kubernetes objects from release manifest: unable to recognize &#34;&#34;: no matches for kind &#34;PodMonitor&#34; in version &#34;monitoring.coreos.com/v1&#34;