### PR TITLE
fix loki aws config

### DIFF
--- a/cluster/apps/observability/loki/helm-release.yaml
+++ b/cluster/apps/observability/loki/helm-release.yaml
@@ -49,6 +49,7 @@ spec:
           secret_access_key: "${SECRET_MINIO_LOKI_SECRET_KEY}"
           s3forcepathstyle: true
           insecure: true
+          region: us-east-1
         boltdb_shipper:
           active_index_directory: /data/loki/index
           cache_location: /data/loki/index_cache


### PR DESCRIPTION
now that vector is sending data to loki, loki is generating errors trying to access minio bucket about missing region.

level=error ts=2022-06-06T15:56:41.423034146Z caller=cached_client.go:64 msg="failed to build cache" err="AuthorizationHeaderMalformed: The authorization header is malformed; the region is wrong; expecting 'us-east-1'.\n\tstatus code: 400, request id: 16F613 ││ level=error ts=2022-06-06T15:56:41.423138632Z caller=table_manager.go:107 msg="error syncing local boltdb files with storage" err="failed to sync index set fake for table index_19149: AuthorizationHeaderMalformed: The authorization header is malformed; the r ││