### PR TITLE
vector remove timestamp rewrite action

### DIFF
--- a/cluster/apps/observability/vector/aggregator/helm-release.yaml
+++ b/cluster/apps/observability/vector/aggregator/helm-release.yaml
@@ -87,7 +87,7 @@ spec:
             codec: json
           batch:
             max_bytes: 2049000
-          out_of_order_action: rewrite_timestamp
+          out_of_order_action: accept
           remove_label_fields: true
           remove_timestamp: true
           labels:


### PR DESCRIPTION
it started working, but not sure why. I want to see if enabling this breaks it again.