### PR TITLE
remove traefik image reference to k8s-at-home

### DIFF
--- a/cluster/apps/networking/traefik/helm-release.yaml
+++ b/cluster/apps/networking/traefik/helm-release.yaml
@@ -19,8 +19,6 @@ spec:
     - name: cert-manager
       namespace: cert-manager
   values:
-    image:
-      name: ghcr.io/k8s-at-home/traefik
     deployment:
       enabled: true
       kind: DaemonSet


### PR DESCRIPTION
k8s-at-home charts and images are being removed.