### PR TITLE
remove default-pool.yaml config

### DIFF
--- a/cluster/core/metallb-system/kustomization.yaml
+++ b/cluster/core/metallb-system/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - helm-release.yaml
-- default-pool.yaml
+# - default-pool.yaml


### PR DESCRIPTION
the crd isn't present yet for metallb upgrade