### PR TITLE
remove metallb entirely

### DIFF
--- a/cluster/core/kustomization.yaml
+++ b/cluster/core/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - namespaces
-- metallb-system
+# - metallb-system
 - system-upgrade
 - rook-ceph
 - cert-manager

--- a/cluster/core/metallb-system/kustomization.yaml
+++ b/cluster/core/metallb-system/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - helm-release.yaml
-# - default-pool.yaml
+- default-pool.yaml


### PR DESCRIPTION
helm upgrade is failing due to configinline no long supported error