### PR TITLE
adjust version of nfs protocol in use by minio pv

### DIFF
--- a/cluster/apps/default/minio/nfs-pvc.yaml
+++ b/cluster/apps/default/minio/nfs-pvc.yaml
@@ -14,7 +14,7 @@ spec:
     server: "wanshitong.${SECRET_DOMAIN}"
     path: /volume10/Minio
   mountOptions:
-    - nfsvers=4.2
+    - nfsvers=4.1
     - nconnect=8
     - hard
     - noatime


### PR DESCRIPTION
this is to match the version used by synology diskstation where the nfs mount lives.