### PR TITLE
remove mount option hard

### DIFF
--- a/cluster/apps/default/minio/nfs-pvc.yaml
+++ b/cluster/apps/default/minio/nfs-pvc.yaml
@@ -15,7 +15,6 @@ spec:
     path: /volume10/Minio
   mountOptions:
     - nconnect=8
-    - hard
     - noatime
 ---
 apiVersion: v1


### PR DESCRIPTION
The minio pod using the volume was failing to access the nfs volume for some reason. Reccomendations to fix it includes removing the hard mount.