### PR TITLE
remove minio temporarily

### DIFF
--- a/cluster/apps/default/minio/kustomization.yaml
+++ b/cluster/apps/default/minio/kustomization.yaml
@@ -4,4 +4,4 @@ kind: Kustomization
 resources:
   - secret.enc.yaml
   - nfs-pvc.yaml
-  - helm-release.yaml
+  # - helm-release.yaml


### PR DESCRIPTION
the minio pod isn't starting, saying it can't access the .minio.sys files. I'm going to spin down this pod for a while and try creating a test pod i can work with to see if i can see the issue without minio.