### PR TITLE
enable rook cluster mgr module

### DIFF
--- a/cluster/core/rook-ceph/storage/helm-release.yaml
+++ b/cluster/core/rook-ceph/storage/helm-release.yaml
@@ -39,6 +39,10 @@ spec:
             hosts:
               - "rook.${SECRET_DOMAIN}"
     cephClusterSpec:
+      mgr:
+        modules:
+          - name: rook
+            enabled: true
       dashboard:
         enabled: true
         urlPrefix: /


### PR DESCRIPTION
trying to get rid of this error
"[WRN]
overall HEALTH_WARN 1 mgr modules have recently crashed" 
Recommended from this thread:
https://github.com/rook/rook/issues/11316#issuecomment-1332520091