### PR TITLE
add securitycontext for prowlarr backup job

### DIFF
--- a/cluster/apps/media/prowlarr/backups/replicationsource.yaml
+++ b/cluster/apps/media/prowlarr/backups/replicationsource.yaml
@@ -15,6 +15,10 @@ spec:
     cacheCapacity: 2Gi
     volumeSnapshotClassName: csi-ceph-blockpool
     storageClassName: ceph-block
+    moverSecurityContext:
+      runAsUser: 568
+      runAsGroup: 568
+      fsGroup: 568
     retain:
       daily: 10
       within: 3d


### PR DESCRIPTION
Latest volsync can't access files due to container now running with reduced permissions.