### PR TITLE
set spec.strategy.type=recreate on mymindinai discordbot deployment

### DIFF
--- a/cluster/apps/mymindinai/discordbot/base/deployment.yaml
+++ b/cluster/apps/mymindinai/discordbot/base/deployment.yaml
@@ -8,6 +8,8 @@ metadata:
     app: mymind-discord-bot
 spec:
   replicas: 1
+  strategy:
+    type: recreate
   selector:
     matchLabels:
       app: mymind-discord-bot


### PR DESCRIPTION
We don't want the two copies of the same bot token communicating with the discord api at once, it could lead to confusion or issues.