### PR TITLE
set rollingUpdate to null for discordbot

### DIFF
--- a/cluster/apps/mymindinai/discordbot/base/deployment.yaml
+++ b/cluster/apps/mymindinai/discordbot/base/deployment.yaml
@@ -10,6 +10,7 @@ spec:
   replicas: 1
   strategy:
     type: Recreate
+    rollingUpdate: null
   selector:
     matchLabels:
       app: mymind-discord-bot


### PR DESCRIPTION
flux isn't removing the default rollingUpdate config and therefore it's blocking the recreate strategy because they can't both be set at the same time.