### PR TITLE
fix username setup for mongodb

### DIFF
--- a/cluster/apps/default/mongodb/helm-release.yaml
+++ b/cluster/apps/default/mongodb/helm-release.yaml
@@ -27,8 +27,8 @@ spec:
     auth:
       rootUser: root
       rootPassword: "${SECRET_MONGODB_PASSWORD}"
-      usernames: ["${SECRET_MONGODB_UNIFI_USERNAME}"]
-      passwords: ["${SECRET_MONGODB_UNIFI_PASSWORD}"]
+      usernames: ["${SECRET_MONGODB_UNIFI_USERNAME}", "${SECRET_MONGODB_UNIFI_USERNAME}"]
+      passwords: ["${SECRET_MONGODB_UNIFI_PASSWORD}", "${SECRET_MONGODB_UNIFI_PASSWORD}"]
       databases: ["UNIFI", "UNIFI_stat"]
     persistence:
       enabled: true


### PR DESCRIPTION
error from chart:
024-01-10T23:06:16.458Z error HelmRelease/mongodb.default - Reconciler error Helm install failed: execution error at (mongodb/templates/NOTES.txt:202:4): VALUES VALIDATION:

mongodb: auth.usernames, auth.databases
    Both auth.usernames and auth.databases arrays should have the same length