### PR TITLE
upgrade mongodb helm chart to 14.5.0

### DIFF
--- a/cluster/apps/default/mongodb/helm-release.yaml
+++ b/cluster/apps/default/mongodb/helm-release.yaml
@@ -8,7 +8,7 @@ spec:
   chart:
     spec:
       chart: mongodb
-      version: 14.3.1
+      version: 14.5.0
       sourceRef:
         kind: HelmRepository
         name: bitnami-charts


### PR DESCRIPTION
trying to get around an error Reconciler error Helm install failed: unable to build kubernetes objects from release manifest: error validating "": error validating data: [ValidationError(CronJob.spec.jobTemplate.spec): unknown field "securityContext" in io.k8s.api.batch.v1.JobSpec, ValidationError(CronJob.spec.jobTemplate.spec.template.spec.containers[0].securityContext): unknown field "enabled" in io.k8s.api.core.v1.SecurityContext]